### PR TITLE
Adds popup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,12 @@
     }
   ],
 
+   "browser_action": {
+      "default_icon": "icons/twitch-time-48.png",
+      "default_title": "Twitch Time",
+      "default_popup": "popup/time_popup.html"
+    },
+
   "permissions": [
     "storage"
   ]

--- a/popup/time_popup.css
+++ b/popup/time_popup.css
@@ -1,0 +1,46 @@
+body {
+    width: 350px;
+    background: #151515;
+    color: #ffffff;
+    padding: 0px;
+    margin: 5px;
+}
+
+h1 {
+    color: #DBE1B4;
+    margin: 5px;
+    padding 0px;
+    text-align: center;
+}
+
+.note {
+    font-size: 75%;
+}
+
+table {
+    width: 100%;
+}
+
+#scrolltable {
+    height: 200px;
+    overflow: auto;
+}
+th {
+    background-color: #505050;
+}
+tr:nth-child(even) {
+    background-color: #303030;
+}
+
+td:nth-child(1) {
+    text-align: left;
+}
+
+td:nth-child(2) {
+    text-align: right;
+}
+
+td:nth-child(1) a {
+    color: #ffffff;
+    text-decoration: none;
+}

--- a/popup/time_popup.html
+++ b/popup/time_popup.html
@@ -1,0 +1,22 @@
+ <!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" href="time_popup.css">
+    </head>
+    <body>
+
+        <h1>Twitch Time</h1>
+        <p>Here you can see your spend time per channel.</p>
+        <div id="scrolltable">
+            <table id="timeTable">
+                <tr>
+                    <th>Channel</th>
+                    <th id="timeCol">Time</th>
+                </tr>
+            </table>
+        </div>
+
+        <script src="time_popup.js"></script>
+    </body>
+</html>

--- a/popup/time_popup.js
+++ b/popup/time_popup.js
@@ -1,0 +1,61 @@
+function sortHostsByTime(channels) {
+    var n = channels.length;
+    for(i = 0; i < n - 1; i++) {
+        for(k = 0; k < n - i - 1; k++) {
+            if(channels[k].time < channels[k+1].time) {
+                var tmp = channels[k];
+                channels[k] = channels[k+1];
+                channels[k+1] = tmp;
+            }
+        }
+    }
+    return channels;
+}
+
+function calcTime(time) {
+  const timeInMinutes = Math.floor(time/60);
+  const timeInHours = Math.floor(time / 3600);
+
+  const days = Math.floor(timeInHours / 24);
+  const hours = timeInHours % 24;
+  const minutes = timeInMinutes % 60;
+
+  var time = {
+      days : days,
+      hours : hours,
+      minutes : minutes
+  };
+
+  return time;
+}
+
+function updateTimeTable(items) {
+    var channelList = [];
+    var timeTable = document.getElementById("timeTable");
+    Object.keys(items).forEach(function(key, index, keys) {
+        let time = items[keys[index]];
+        var channel = {name: key, time: time};
+        channelList.push(channel);
+    });
+
+    channelList = sortHostsByTime(channelList);
+    channelList.forEach(function(channel) {
+        var row = timeTable.insertRow(-1);
+        var channelCell = row.insertCell(0);
+        var timeCell = row.insertCell(1);
+
+        let link = document.createElement("a");
+        link.href = "https://twitch.tv/" + channel.name;
+        link.innerHTML = channel.name;
+
+        channelCell.appendChild(link);
+        var time = calcTime(channel.time);
+        timeCell.innerHTML = time.days + "d " + time.hours + "h " + time.minutes + "m";
+    });
+}
+
+function onError(error) {
+    console.log(error);
+}
+
+browser.storage.sync.get(null).then(updateTimeTable, onError);


### PR DESCRIPTION
Hey again,

like mentioned i tried the `list` idea as a popup. These is the result:
![twitch_time_1](https://user-images.githubusercontent.com/11677107/61172630-3501f700-a587-11e9-936a-4ec48a9cbe29.png)
![twitch_time_2](https://user-images.githubusercontent.com/11677107/61172635-39c6ab00-a587-11e9-9150-3eb798cdfb9c.png)

The colors are pretty much random and i like a dark theme (idea would be a small checkbox to toggle between a light and dark theme).
I though of using the twitch colors at the background but its a hard contrast so i used the dark grey.

I dont know about the time formatting. I used the same format like the injected div. Alternative:
`dd:hh:mm`

The channel names can be clicked to open the stream. Just an idea, dont know if it is a 'nice have' feature.

Looking forward to your suggestions 

Take care!
Tuc

#### commit msg
```
- adds html and css for popup
- reads complete storage
- all channels are added with there name and time to the list
- channels can be clicked
- channels are sorted by highest time (bubble sort)
```